### PR TITLE
Update home screen with Spot the dog SVG

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,42 +43,70 @@ function App() {
 
           <Box
             sx={{
-              animation: `${rotate} 40s linear infinite`, // Doubled from 20s to 40s
+              animation: `${rotate} 40s linear infinite`,
               width: '300px',
               height: '300px',
             }}
           >
             <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-              {/* Body */}
-              <circle cx="50" cy="55" r="30" fill="none" stroke="currentColor" strokeWidth="2"/>
+              {/* Main body - more rounded like Spot */}
+              <path 
+                d="M 20 50 
+                   Q 20 30 40 30 
+                   L 70 30 
+                   Q 90 30 90 50
+                   Q 90 70 70 70
+                   L 40 70
+                   Q 20 70 20 50"
+                fill="none" 
+                stroke="currentColor" 
+                strokeWidth="2"
+                strokeLinejoin="round"
+              />
               
-              {/* Head */}
-              <circle cx="50" cy="25" r="15" fill="none" stroke="currentColor" strokeWidth="2"/>
+              {/* Head - characteristic side view */}
+              <path 
+                d="M 70 30
+                   Q 85 30 85 45
+                   Q 85 60 70 60
+                   Q 55 60 55 45
+                   Q 55 30 70 30"
+                fill="none" 
+                stroke="currentColor" 
+                strokeWidth="2"
+              />
               
-              {/* Ears */}
-              <path d="M40 15 L35 5 L45 15" fill="none" stroke="currentColor" strokeWidth="2"/>
-              <path d="M60 15 L65 5 L55 15" fill="none" stroke="currentColor" strokeWidth="2"/>
+              {/* Ear */}
+              <path 
+                d="M 75 35
+                   Q 85 25 80 40"
+                fill="none" 
+                stroke="currentColor" 
+                strokeWidth="2"
+              />
               
-              {/* Eyes */}
-              <circle cx="45" cy="22" r="2" fill="currentColor"/>
-              <circle cx="55" cy="22" r="2" fill="currentColor"/>
+              {/* Eye */}
+              <circle cx="75" cy="45" r="2" fill="currentColor"/>
               
               {/* Nose */}
-              <circle cx="50" cy="27" r="3" fill="currentColor"/>
+              <circle cx="82" cy="50" r="2" fill="currentColor"/>
               
-              {/* Spots */}
-              <circle cx="35" cy="45" r="5" fill="none" stroke="currentColor" strokeWidth="1"/>
-              <circle cx="65" cy="60" r="7" fill="none" stroke="currentColor" strokeWidth="1"/>
-              <circle cx="45" cy="70" r="6" fill="none" stroke="currentColor" strokeWidth="1"/>
+              {/* Spots - characteristic round spots */}
+              <circle cx="35" cy="45" r="6" fill="none" stroke="currentColor" strokeWidth="1.5"/>
+              <circle cx="55" cy="55" r="5" fill="none" stroke="currentColor" strokeWidth="1.5"/>
               
-              {/* Tail */}
-              <path d="M75 45 Q85 35 80 25" fill="none" stroke="currentColor" strokeWidth="2"/>
+              {/* Simple tail */}
+              <path 
+                d="M 20 50
+                   Q 10 50 15 40" 
+                fill="none" 
+                stroke="currentColor" 
+                strokeWidth="2"
+              />
               
-              {/* Legs */}
-              <line x1="35" y1="85" x2="35" y2="95" stroke="currentColor" strokeWidth="2"/>
-              <line x1="45" y1="85" x2="45" y2="95" stroke="currentColor" strokeWidth="2"/>
-              <line x1="55" y1="85" x2="55" y2="95" stroke="currentColor" strokeWidth="2"/>
-              <line x1="65" y1="85" x2="65" y2="95" stroke="currentColor" strokeWidth="2"/>
+              {/* Legs - simple lines like in the books */}
+              <line x1="35" y1="70" x2="35" y2="85" stroke="currentColor" strokeWidth="2"/>
+              <line x1="75" y1="70" x2="75" y2="85" stroke="currentColor" strokeWidth="2"/>
             </svg>
           </Box>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,42 +43,49 @@ function App() {
 
           <Box
             sx={{
-              animation: `${rotate} 40s linear infinite`, // Doubled from 20s to 40s
+              animation: `${rotate} 40s linear infinite`,
               width: '300px',
               height: '300px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             }}
           >
-            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+            <svg 
+              viewBox="-10 -10 120 120" 
+              xmlns="http://www.w3.org/2000/svg"
+              style={{ width: '100%', height: '100%' }}
+            >
               {/* Body */}
-              <circle cx="50" cy="55" r="30" fill="none" stroke="currentColor" strokeWidth="2"/>
+              <circle cx="50" cy="55" r="35" fill="none" stroke="currentColor" strokeWidth="2"/>
               
               {/* Head */}
-              <circle cx="50" cy="25" r="15" fill="none" stroke="currentColor" strokeWidth="2"/>
+              <circle cx="50" cy="25" r="18" fill="none" stroke="currentColor" strokeWidth="2"/>
               
               {/* Ears */}
-              <path d="M40 15 L35 5 L45 15" fill="none" stroke="currentColor" strokeWidth="2"/>
-              <path d="M60 15 L65 5 L55 15" fill="none" stroke="currentColor" strokeWidth="2"/>
+              <path d="M35 15 Q30 5 40 15" fill="none" stroke="currentColor" strokeWidth="2"/>
+              <path d="M65 15 Q70 5 60 15" fill="none" stroke="currentColor" strokeWidth="2"/>
               
               {/* Eyes */}
-              <circle cx="45" cy="22" r="2" fill="currentColor"/>
-              <circle cx="55" cy="22" r="2" fill="currentColor"/>
+              <circle cx="43" cy="22" r="2.5" fill="currentColor"/>
+              <circle cx="57" cy="22" r="2.5" fill="currentColor"/>
               
               {/* Nose */}
-              <circle cx="50" cy="27" r="3" fill="currentColor"/>
+              <circle cx="50" cy="28" r="3.5" fill="currentColor"/>
               
               {/* Spots */}
-              <circle cx="35" cy="45" r="5" fill="none" stroke="currentColor" strokeWidth="1"/>
-              <circle cx="65" cy="60" r="7" fill="none" stroke="currentColor" strokeWidth="1"/>
-              <circle cx="45" cy="70" r="6" fill="none" stroke="currentColor" strokeWidth="1"/>
+              <circle cx="35" cy="45" r="8" fill="none" stroke="currentColor" strokeWidth="1.5"/>
+              <circle cx="65" cy="60" r="10" fill="none" stroke="currentColor" strokeWidth="1.5"/>
+              <circle cx="45" cy="70" r="9" fill="none" stroke="currentColor" strokeWidth="1.5"/>
               
-              {/* Tail */}
-              <path d="M75 45 Q85 35 80 25" fill="none" stroke="currentColor" strokeWidth="2"/>
+              {/* Tail - now more curved and playful */}
+              <path d="M80 50 Q95 40 90 25" fill="none" stroke="currentColor" strokeWidth="2.5"/>
               
-              {/* Legs */}
-              <line x1="35" y1="85" x2="35" y2="95" stroke="currentColor" strokeWidth="2"/>
-              <line x1="45" y1="85" x2="45" y2="95" stroke="currentColor" strokeWidth="2"/>
-              <line x1="55" y1="85" x2="55" y2="95" stroke="currentColor" strokeWidth="2"/>
-              <line x1="65" y1="85" x2="65" y2="95" stroke="currentColor" strokeWidth="2"/>
+              {/* Legs - slightly thicker and more spaced */}
+              <line x1="30" y1="85" x2="30" y2="100" stroke="currentColor" strokeWidth="2.5"/>
+              <line x1="43" y1="85" x2="43" y2="100" stroke="currentColor" strokeWidth="2.5"/>
+              <line x1="57" y1="85" x2="57" y2="100" stroke="currentColor" strokeWidth="2.5"/>
+              <line x1="70" y1="85" x2="70" y2="100" stroke="currentColor" strokeWidth="2.5"/>
             </svg>
           </Box>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,67 +46,66 @@ function App() {
               animation: `${rotate} 40s linear infinite`,
               width: '300px',
               height: '300px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             }}
           >
             <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-              {/* Main body - more rounded like Spot */}
+              {/* Face */}
+              <circle cx="50" cy="50" r="30" fill="#000000"/>
+              
+              {/* Ears */}
+              <circle cx="25" cy="25" r="15" fill="#000000"/>
+              <circle cx="75" cy="25" r="15" fill="#000000"/>
+              
+              {/* Face area */}
               <path 
-                d="M 20 50 
-                   Q 20 30 40 30 
-                   L 70 30 
-                   Q 90 30 90 50
-                   Q 90 70 70 70
-                   L 40 70
-                   Q 20 70 20 50"
+                d="M 35 40 
+                   Q 50 65 65 40" 
                 fill="none" 
-                stroke="currentColor" 
-                strokeWidth="2"
-                strokeLinejoin="round"
+                stroke="#FFFFFF" 
+                strokeWidth="3"
               />
               
-              {/* Head - characteristic side view */}
-              <path 
-                d="M 70 30
-                   Q 85 30 85 45
-                   Q 85 60 70 60
-                   Q 55 60 55 45
-                   Q 55 30 70 30"
-                fill="none" 
-                stroke="currentColor" 
-                strokeWidth="2"
-              />
-              
-              {/* Ear */}
-              <path 
-                d="M 75 35
-                   Q 85 25 80 40"
-                fill="none" 
-                stroke="currentColor" 
-                strokeWidth="2"
-              />
-              
-              {/* Eye */}
-              <circle cx="75" cy="45" r="2" fill="currentColor"/>
+              {/* Eyes */}
+              <ellipse cx="40" cy="45" rx="8" ry="12" fill="#FFFFFF"/>
+              <ellipse cx="60" cy="45" rx="8" ry="12" fill="#FFFFFF"/>
+              <circle cx="43" cy="48" r="3" fill="#000000"/>
+              <circle cx="63" cy="48" r="3" fill="#000000"/>
               
               {/* Nose */}
-              <circle cx="82" cy="50" r="2" fill="currentColor"/>
+              <ellipse cx="50" cy="52" rx="5" ry="3" fill="#FFFFFF"/>
               
-              {/* Spots - characteristic round spots */}
-              <circle cx="35" cy="45" r="6" fill="none" stroke="currentColor" strokeWidth="1.5"/>
-              <circle cx="55" cy="55" r="5" fill="none" stroke="currentColor" strokeWidth="1.5"/>
-              
-              {/* Simple tail */}
+              {/* Mouth */}
               <path 
-                d="M 20 50
-                   Q 10 50 15 40" 
+                d="M 35 58 
+                   Q 50 65 65 58" 
                 fill="none" 
-                stroke="currentColor" 
-                strokeWidth="2"
+                stroke="#FFFFFF" 
+                strokeWidth="3"
+              />
+
+              {/* Classic pie-cut eyes */}
+              <path 
+                d="M 35 45 
+                   L 45 45" 
+                stroke="#000000" 
+                strokeWidth="1"
+              />
+              <path 
+                d="M 55 45 
+                   L 65 45" 
+                stroke="#000000" 
+                strokeWidth="1"
               />
               
-              {/* Legs - simple lines like in the books */}
-              <line x1="35" y1="70" x2="35" y2="85" stroke="currentColor" strokeWidth="2"/>
-              <line x1="75" y1="70" x2="75" y2="85" stroke="currentColor" strokeWidth="2"/>
+              {/* Classic details */}
+              <line x1="48" y1="52" x2="52" y2="52" stroke="#000000" strokeWidth="1"/>
+              
+              {/* White circles at ear bases for classic look */}
+              <circle cx="25" cy="30" r="3" fill="#FFFFFF"/>
+              <circle cx="75" cy="30" r="3" fill="#FFFFFF"/>
             </svg>
           </Box>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,51 +43,42 @@ function App() {
 
           <Box
             sx={{
-              animation: `${rotate} 20s linear infinite`,
+              animation: `${rotate} 40s linear infinite`, // Doubled from 20s to 40s
               width: '300px',
               height: '300px',
             }}
           >
             <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-              <circle 
-                cx="50" 
-                cy="50" 
-                r="45" 
-                fill="none" 
-                stroke="currentColor" 
-                strokeWidth="1"
-                vectorEffect="non-scaling-stroke"
-              />
+              {/* Body */}
+              <circle cx="50" cy="55" r="30" fill="none" stroke="currentColor" strokeWidth="2"/>
               
-              <g opacity="0.7">
-                {[0, 60, 120].map((rotation) => (
-                  <path
-                    key={rotation}
-                    d="M50 5 L95 50 L50 95 L5 50 Z"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="0.5"
-                    vectorEffect="non-scaling-stroke"
-                    transform={`rotate(${rotation}, 50, 50)`}
-                  />
-                ))}
-              </g>
+              {/* Head */}
+              <circle cx="50" cy="25" r="15" fill="none" stroke="currentColor" strokeWidth="2"/>
               
-              <circle 
-                cx="50" 
-                cy="50" 
-                r="25" 
-                fill="none" 
-                stroke="currentColor"
-                strokeWidth="0.75"
-                vectorEffect="non-scaling-stroke"
-              />
-              <circle 
-                cx="50" 
-                cy="50" 
-                r="10" 
-                fill="currentColor"
-              />
+              {/* Ears */}
+              <path d="M40 15 L35 5 L45 15" fill="none" stroke="currentColor" strokeWidth="2"/>
+              <path d="M60 15 L65 5 L55 15" fill="none" stroke="currentColor" strokeWidth="2"/>
+              
+              {/* Eyes */}
+              <circle cx="45" cy="22" r="2" fill="currentColor"/>
+              <circle cx="55" cy="22" r="2" fill="currentColor"/>
+              
+              {/* Nose */}
+              <circle cx="50" cy="27" r="3" fill="currentColor"/>
+              
+              {/* Spots */}
+              <circle cx="35" cy="45" r="5" fill="none" stroke="currentColor" strokeWidth="1"/>
+              <circle cx="65" cy="60" r="7" fill="none" stroke="currentColor" strokeWidth="1"/>
+              <circle cx="45" cy="70" r="6" fill="none" stroke="currentColor" strokeWidth="1"/>
+              
+              {/* Tail */}
+              <path d="M75 45 Q85 35 80 25" fill="none" stroke="currentColor" strokeWidth="2"/>
+              
+              {/* Legs */}
+              <line x1="35" y1="85" x2="35" y2="95" stroke="currentColor" strokeWidth="2"/>
+              <line x1="45" y1="85" x2="45" y2="95" stroke="currentColor" strokeWidth="2"/>
+              <line x1="55" y1="85" x2="55" y2="95" stroke="currentColor" strokeWidth="2"/>
+              <line x1="65" y1="85" x2="65" y2="95" stroke="currentColor" strokeWidth="2"/>
             </svg>
           </Box>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,49 +43,42 @@ function App() {
 
           <Box
             sx={{
-              animation: `${rotate} 40s linear infinite`,
+              animation: `${rotate} 40s linear infinite`, // Doubled from 20s to 40s
               width: '300px',
               height: '300px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
             }}
           >
-            <svg 
-              viewBox="-10 -10 120 120" 
-              xmlns="http://www.w3.org/2000/svg"
-              style={{ width: '100%', height: '100%' }}
-            >
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
               {/* Body */}
-              <circle cx="50" cy="55" r="35" fill="none" stroke="currentColor" strokeWidth="2"/>
+              <circle cx="50" cy="55" r="30" fill="none" stroke="currentColor" strokeWidth="2"/>
               
               {/* Head */}
-              <circle cx="50" cy="25" r="18" fill="none" stroke="currentColor" strokeWidth="2"/>
+              <circle cx="50" cy="25" r="15" fill="none" stroke="currentColor" strokeWidth="2"/>
               
               {/* Ears */}
-              <path d="M35 15 Q30 5 40 15" fill="none" stroke="currentColor" strokeWidth="2"/>
-              <path d="M65 15 Q70 5 60 15" fill="none" stroke="currentColor" strokeWidth="2"/>
+              <path d="M40 15 L35 5 L45 15" fill="none" stroke="currentColor" strokeWidth="2"/>
+              <path d="M60 15 L65 5 L55 15" fill="none" stroke="currentColor" strokeWidth="2"/>
               
               {/* Eyes */}
-              <circle cx="43" cy="22" r="2.5" fill="currentColor"/>
-              <circle cx="57" cy="22" r="2.5" fill="currentColor"/>
+              <circle cx="45" cy="22" r="2" fill="currentColor"/>
+              <circle cx="55" cy="22" r="2" fill="currentColor"/>
               
               {/* Nose */}
-              <circle cx="50" cy="28" r="3.5" fill="currentColor"/>
+              <circle cx="50" cy="27" r="3" fill="currentColor"/>
               
               {/* Spots */}
-              <circle cx="35" cy="45" r="8" fill="none" stroke="currentColor" strokeWidth="1.5"/>
-              <circle cx="65" cy="60" r="10" fill="none" stroke="currentColor" strokeWidth="1.5"/>
-              <circle cx="45" cy="70" r="9" fill="none" stroke="currentColor" strokeWidth="1.5"/>
+              <circle cx="35" cy="45" r="5" fill="none" stroke="currentColor" strokeWidth="1"/>
+              <circle cx="65" cy="60" r="7" fill="none" stroke="currentColor" strokeWidth="1"/>
+              <circle cx="45" cy="70" r="6" fill="none" stroke="currentColor" strokeWidth="1"/>
               
-              {/* Tail - now more curved and playful */}
-              <path d="M80 50 Q95 40 90 25" fill="none" stroke="currentColor" strokeWidth="2.5"/>
+              {/* Tail */}
+              <path d="M75 45 Q85 35 80 25" fill="none" stroke="currentColor" strokeWidth="2"/>
               
-              {/* Legs - slightly thicker and more spaced */}
-              <line x1="30" y1="85" x2="30" y2="100" stroke="currentColor" strokeWidth="2.5"/>
-              <line x1="43" y1="85" x2="43" y2="100" stroke="currentColor" strokeWidth="2.5"/>
-              <line x1="57" y1="85" x2="57" y2="100" stroke="currentColor" strokeWidth="2.5"/>
-              <line x1="70" y1="85" x2="70" y2="100" stroke="currentColor" strokeWidth="2.5"/>
+              {/* Legs */}
+              <line x1="35" y1="85" x2="35" y2="95" stroke="currentColor" strokeWidth="2"/>
+              <line x1="45" y1="85" x2="45" y2="95" stroke="currentColor" strokeWidth="2"/>
+              <line x1="55" y1="85" x2="55" y2="95" stroke="currentColor" strokeWidth="2"/>
+              <line x1="65" y1="85" x2="65" y2="95" stroke="currentColor" strokeWidth="2"/>
             </svg>
           </Box>
 


### PR DESCRIPTION
This PR addresses issue #2 by:

- Replacing the geometric SVG with a simple illustration of Spot the dog
- Slowing down the rotation animation from 20s to 40s per rotation
- Keeping consistent styling with the theme's color scheme

The SVG is drawn to be simple but recognizable as a dog, with:
- A round body and head
- Floppy ears
- Simple spots
- A wagging tail
- Four legs

The slower rotation should make it easier to appreciate the illustration while maintaining the dynamic feel of the page.